### PR TITLE
v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/latest-news",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A script that loads blogs posts into a given template",
   "main": "src/index.js",
   "iife": "dist/latest-news.js",


### PR DESCRIPTION
## Done

-  bump version to `v1.3.0` (relates to https://github.com/canonical-web-and-design/latest-news/pull/36)
