### PR TITLE
Add support for article group

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The script will look for the following class names to use as hooks for content w
 - `article-title`: The title of the article
 - `article-image`: The featured image of the article
 - `article-excerpt`: The excerpt of the article
+- `article-group`: The group of the article
+
 
 You can choose what content to display and how it will look by using the above classes. If you don't want a certain part of the content, for example the article image, then do not include an element with the class name of `article-image`.
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ function articleDiv(article, articleTemplateSelector, options) {
   var image = articleFragment.querySelector(".article-image");
   var author = articleFragment.querySelector(".article-author");
   var excerpt = articleFragment.querySelector(".article-excerpt");
+  var group = articleFragment.querySelector(".article-group");
   var url = "";
   var imageLink = document.createElement("a");
 
@@ -71,6 +72,10 @@ function articleDiv(article, articleTemplateSelector, options) {
 
   if (excerpt) {
     excerpt.innerHTML = article.excerpt.rendered;
+  }
+
+  if (group) {
+    group.innerHTML = article.group.name;
   }
 
   if (time) {


### PR DESCRIPTION
## Done

- Adds support for article group, to fullfill the use case on the front page of canonical-v3

## QA

- Open project on this branch
- Edit HTML to add an element with the `article-group` class
- run yarn build > yarn server
- Open the project in local and check the article group is being pulled and displayed

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5510
