### PR TITLE
Allow passing of `excerptLength` as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ You will need to pass some options to the script in order for it to know where t
 - `groupId`: Integer - Return posts in a specific group (Optional)
 - `gtmEventLabel`: String - An event label used for Google Analytics (Optional)
 - `hostname`: String - An optional hostname to be used for the permalink. By default the link is relative (Optional)
-- `limit`: Integer - The number of posts to be returned. (Optional)
+- `limit`: Integer - The number of posts to be returned (Optional)
 - `linkImage`: Boolean - Wrap the thumbnail image in a link (Optional)
-- `spotlightContainerSelector`: String - The container where the spotlight article will be displayed
-- `spotlightTemplateSelector`: String - The template that will be used for the spotlight article
+- `spotlightContainerSelector`: String - The container where the spotlight article will be displayed (Optional)
+- `spotlightTemplateSelector`: String - The template that will be used for the spotlight article (Optional)
 - `tagId`: Integer - Return posts with a specific tag (Optional)
+- `excerptLength`: Integer - Specifies the approximate number of characters included in the excerpt (Optional)
 
 ## Building
 

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/canonical-web-and-design/latest-news.git"
+    "url": "git+https://github.com/canonical/latest-news.git"
   },
   "author": "Canonical",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/canonical-web-and-design/latest-news/issues"
+    "url": "https://github.com/canonical/latest-news/issues"
   },
-  "homepage": "https://github.com/canonical-web-and-design/latest-news#readme",
+  "homepage": "https://github.com/canonical/latest-news#readme",
   "devDependencies": {
     "@babel/core": "7.16.7",
     "@babel/preset-env": "7.16.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/latest-news",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A script that loads blogs posts into a given template",
   "main": "src/index.js",
   "iife": "dist/latest-news.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist && rollup -c",
     "serve": "http-server",
     "test": "jest",
-    "lint": "eslint src/**/*.js && prettier src/**/*.js --check",
+    "lint": "eslint src/**/*.js && prettier src/**/*.js --write",
     "prepublishOnly": "npm run build",
     "watch": "rollup -c -w",
     "clean": "rm -rf node_modules && rm -rf dist"

--- a/src/index.js
+++ b/src/index.js
@@ -8,27 +8,8 @@ function revealSection() {
 
 function formatDate(date) {
   var parsedDate = new Date(date);
-  var monthNames = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-  ];
-  return (
-    parsedDate.getDate() +
-    " " +
-    monthNames[parsedDate.getMonth()] +
-    " " +
-    parsedDate.getFullYear()
-  );
+  var monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+  return parsedDate.getDate() + " " + monthNames[parsedDate.getMonth()] + " " + parsedDate.getFullYear();
 }
 
 function articleDiv(article, articleTemplateSelector, options) {
@@ -49,20 +30,13 @@ function articleDiv(article, articleTemplateSelector, options) {
 
   var articleImage;
 
-  if (
-    article._embedded &&
-    article._embedded["wp:featuredmedia"] &&
-    article._embedded["wp:featuredmedia"][0] &&
-    article._embedded["wp:featuredmedia"][0].media_details &&
-    article._embedded["wp:featuredmedia"][0].media_details.width &&
-    article._embedded["wp:featuredmedia"][0].media_details.height
-  ) {
+  if (article._embedded && article._embedded["wp:featuredmedia"] && article._embedded["wp:featuredmedia"][0] && article._embedded["wp:featuredmedia"][0].media_details && article._embedded["wp:featuredmedia"][0].media_details.width && article._embedded["wp:featuredmedia"][0].media_details.height) {
     var media = article._embedded["wp:featuredmedia"][0];
     articleImage = {
       url: media.source_url,
       alt: media.alt_text,
       width: media.media_details.width,
-      height: media.media_details.height,
+      height: media.media_details.height
     };
   }
 
@@ -71,7 +45,33 @@ function articleDiv(article, articleTemplateSelector, options) {
   }
 
   if (excerpt) {
-    excerpt.innerHTML = article.excerpt.rendered;
+    if (options.excerptLength) {
+      var originalExcerpt = article.excerpt.rendered;
+
+      if (originalExcerpt.length <= options.excerptLength) {
+        excerpt.innerHTML = originalExcerpt;
+      } else {
+        var lastSpaceIndex = originalExcerpt.lastIndexOf(' ', options.excerptLength);
+
+        if (lastSpaceIndex === -1) {
+          lastSpaceIndex = options.excerptLength;
+        }
+
+        originalExcerpt = originalExcerpt.substring(0, lastSpaceIndex);
+
+        for (var i = originalExcerpt.length - 1; i >= 0; i--) {
+          if (!/[a-zA-Z0-9]/.test(originalExcerpt[i])) {
+            originalExcerpt = originalExcerpt.substring(0, i);
+          } else {
+            break;
+          }
+        }
+
+        excerpt.innerHTML = originalExcerpt + "&nbsp;&hellip;";
+      }
+    } else {
+      excerpt.innerHTML = article.excerpt.rendered;
+    }
   }
 
   if (group) {
@@ -92,7 +92,7 @@ function articleDiv(article, articleTemplateSelector, options) {
           event: "GAEvent",
           eventCategory: "blog",
           eventAction: options.gtmEventLabel + " news link",
-          eventLabel: article.slug,
+          eventLabel: article.slug
         });
       };
     }
@@ -143,9 +143,7 @@ function getTemplate(selector) {
 
 function latestArticlesCallback(options) {
   return function (event) {
-    var articlesContainer = document.querySelector(
-      options.articlesContainerSelector
-    );
+    var articlesContainer = document.querySelector(options.articlesContainerSelector);
 
     if (articlesContainer) {
       while (articlesContainer.hasChildNodes()) {
@@ -155,21 +153,13 @@ function latestArticlesCallback(options) {
       var data = JSON.parse(event.target.responseText);
 
       if ("spotlightContainerSelector" in options) {
-        var spotlightContainer = document.querySelector(
-          options.spotlightContainerSelector
-        );
+        var spotlightContainer = document.querySelector(options.spotlightContainerSelector);
 
         if (spotlightContainer) {
           var latestPinned = data.latest_pinned_articles[0];
 
           if (latestPinned) {
-            spotlightContainer.appendChild(
-              articleDiv(
-                latestPinned,
-                options.spotlightTemplateSelector,
-                options
-              )
-            );
+            spotlightContainer.appendChild(articleDiv(latestPinned, options.spotlightTemplateSelector, options));
           }
         } else {
           console.warn("latest-news: No spotlight container found");
@@ -178,9 +168,7 @@ function latestArticlesCallback(options) {
 
       if (data.latest_articles) {
         data.latest_articles.forEach(function (article) {
-          articlesContainer.appendChild(
-            articleDiv(article, options.articleTemplateSelector, options)
-          );
+          articlesContainer.appendChild(articleDiv(article, options.articleTemplateSelector, options));
         });
       }
     } else {
@@ -220,12 +208,5 @@ if (typeof window.fetchLatestNews == "undefined") {
   window.fetchLatestNews = fetchLatestNews;
 }
 
-export {
-  articleDiv,
-  fetchLatestNews,
-  formatDate,
-  getTemplate,
-  latestArticlesCallback,
-  revealSection,
-};
+export { articleDiv, fetchLatestNews, formatDate, getTemplate, latestArticlesCallback, revealSection };
 //# sourceMappingURL=index.js.map

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ function articleDiv(article, articleTemplateSelector, options) {
           }
         }
 
-        excerpt.innerHTML = originalExcerpt + "&nbsp;&hellip;";
+        excerpt.innerHTML = originalExcerpt + "&hellip;";
       }
     } else {
       excerpt.innerHTML = article.excerpt.rendered;

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,27 @@ function revealSection() {
 
 function formatDate(date) {
   var parsedDate = new Date(date);
-  var monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-  return parsedDate.getDate() + " " + monthNames[parsedDate.getMonth()] + " " + parsedDate.getFullYear();
+  var monthNames = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+  return (
+    parsedDate.getDate() +
+    " " +
+    monthNames[parsedDate.getMonth()] +
+    " " +
+    parsedDate.getFullYear()
+  );
 }
 
 function articleDiv(article, articleTemplateSelector, options) {
@@ -30,13 +49,20 @@ function articleDiv(article, articleTemplateSelector, options) {
 
   var articleImage;
 
-  if (article._embedded && article._embedded["wp:featuredmedia"] && article._embedded["wp:featuredmedia"][0] && article._embedded["wp:featuredmedia"][0].media_details && article._embedded["wp:featuredmedia"][0].media_details.width && article._embedded["wp:featuredmedia"][0].media_details.height) {
+  if (
+    article._embedded &&
+    article._embedded["wp:featuredmedia"] &&
+    article._embedded["wp:featuredmedia"][0] &&
+    article._embedded["wp:featuredmedia"][0].media_details &&
+    article._embedded["wp:featuredmedia"][0].media_details.width &&
+    article._embedded["wp:featuredmedia"][0].media_details.height
+  ) {
     var media = article._embedded["wp:featuredmedia"][0];
     articleImage = {
       url: media.source_url,
       alt: media.alt_text,
       width: media.media_details.width,
-      height: media.media_details.height
+      height: media.media_details.height,
     };
   }
 
@@ -51,7 +77,10 @@ function articleDiv(article, articleTemplateSelector, options) {
       if (originalExcerpt.length <= options.excerptLength) {
         excerpt.innerHTML = originalExcerpt;
       } else {
-        var lastSpaceIndex = originalExcerpt.lastIndexOf(' ', options.excerptLength);
+        var lastSpaceIndex = originalExcerpt.lastIndexOf(
+          " ",
+          options.excerptLength
+        );
 
         if (lastSpaceIndex === -1) {
           lastSpaceIndex = options.excerptLength;
@@ -92,7 +121,7 @@ function articleDiv(article, articleTemplateSelector, options) {
           event: "GAEvent",
           eventCategory: "blog",
           eventAction: options.gtmEventLabel + " news link",
-          eventLabel: article.slug
+          eventLabel: article.slug,
         });
       };
     }
@@ -143,7 +172,9 @@ function getTemplate(selector) {
 
 function latestArticlesCallback(options) {
   return function (event) {
-    var articlesContainer = document.querySelector(options.articlesContainerSelector);
+    var articlesContainer = document.querySelector(
+      options.articlesContainerSelector
+    );
 
     if (articlesContainer) {
       while (articlesContainer.hasChildNodes()) {
@@ -153,13 +184,21 @@ function latestArticlesCallback(options) {
       var data = JSON.parse(event.target.responseText);
 
       if ("spotlightContainerSelector" in options) {
-        var spotlightContainer = document.querySelector(options.spotlightContainerSelector);
+        var spotlightContainer = document.querySelector(
+          options.spotlightContainerSelector
+        );
 
         if (spotlightContainer) {
           var latestPinned = data.latest_pinned_articles[0];
 
           if (latestPinned) {
-            spotlightContainer.appendChild(articleDiv(latestPinned, options.spotlightTemplateSelector, options));
+            spotlightContainer.appendChild(
+              articleDiv(
+                latestPinned,
+                options.spotlightTemplateSelector,
+                options
+              )
+            );
           }
         } else {
           console.warn("latest-news: No spotlight container found");
@@ -168,7 +207,9 @@ function latestArticlesCallback(options) {
 
       if (data.latest_articles) {
         data.latest_articles.forEach(function (article) {
-          articlesContainer.appendChild(articleDiv(article, options.articleTemplateSelector, options));
+          articlesContainer.appendChild(
+            articleDiv(article, options.articleTemplateSelector, options)
+          );
         });
       }
     } else {
@@ -208,5 +249,12 @@ if (typeof window.fetchLatestNews == "undefined") {
   window.fetchLatestNews = fetchLatestNews;
 }
 
-export { articleDiv, fetchLatestNews, formatDate, getTemplate, latestArticlesCallback, revealSection };
+export {
+  articleDiv,
+  fetchLatestNews,
+  formatDate,
+  getTemplate,
+  latestArticlesCallback,
+  revealSection,
+};
 //# sourceMappingURL=index.js.map


### PR DESCRIPTION
## Done

- Allow passing of `excerptLength` as an option, this will trim the excerpt to the given character length to the nearest whole word.
- Updates the readme to include this option 

## QA

- Check out this branch locally
- Go into `index.html` and add `<p class="article-excerpt"></p>` to the example template
- In the same file, find where `fetchLatestNews` is called and add `excerptLength: 100` to the options object
- run the example page with `yarn serve`
- Check that the excerpt length changes depending on the number passes and ends on a whole word with an ellipsis (...)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6977
