### PR TITLE
feat(Article Images): add classes to the article image element

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You will need to pass some options to the script in order for it to know where t
 - `groupId`: Integer - Return posts in a specific group (Optional)
 - `gtmEventLabel`: String - An event label used for Google Analytics (Optional)
 - `hostname`: String - An optional hostname to be used for the permalink. By default the link is relative (Optional)
+- `imageClasses`: Array<String> - A list of classes that will be added to the image element (Optional)
 - `limit`: Integer - The number of posts to be returned (Optional)
 - `linkImage`: Boolean - Wrap the thumbnail image in a link (Optional)
 - `spotlightContainerSelector`: String - The container where the spotlight article will be displayed (Optional)

--- a/src/index.js
+++ b/src/index.js
@@ -154,6 +154,10 @@ function articleDiv(article, articleTemplateSelector, options) {
     img.setAttribute("width", articleImage.width);
     img.setAttribute("height", articleImage.height);
 
+    if (options.imageClasses) {
+      img.classList.add(...options.imageClasses);
+    }
+
     if (options.linkImage) {
       imageLink.appendChild(img);
     } else {


### PR DESCRIPTION
## Done

- Adds `options.imageClasses` to `fetchLatestNews()` options, which allows the caller to specify HTML classes to add to the rendered article image.

## QA

1. Check out a project that uses the `latest-news` module.
2. Replace the import of the current version of the module with the [version proposed in this PR](https://github.com/jmuzina/latest-news/blob/92dbf365959a23d9894d23981e7cd10480d62fc7/src/index.js)
3. Add `imageClasses: ["someClass", "someOtherClass"]` to the options of `fetchLatestNews()`.
4. Verify that `someClass` and `someOtherClass` are added to the `img` element rendered into the template.
5. You can also look at the [WIP Blog pattern](https://github.com/canonical/vanilla-framework/pull/5659) and see that [this example](https://vanilla-framework-5659.demos.haus/docs/examples/patterns/blog/dynamic-responsive?theme=light) adds `p-image-container__image` classes to the article images. 

## Issue / Card

Fixes #54 

## Screenshots

With example `fetchLatestNews()` call in the [Vanilla Blog pattern](https://github.com/canonical/vanilla-framework/pull/5659):

```javascript
  fetchLatestNews({
    articlesContainerSelector: '#articles',
    articleTemplateSelector: '#template',
    gtmEventLabel: 'Vanilla Blog pattern template example',
    limit: '3',
    excerptLength: 180,
    imageClasses: ['p-image-container__image', 'someOtherClass']
  });
```


<img width="1819" height="482" alt="image" src="https://github.com/user-attachments/assets/02f9decd-9b7a-44db-b09b-7ebc668e65e4" />
