### PR TITLE
chore: Bump version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/latest-news",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A script that loads blogs posts into a given template",
   "main": "src/index.js",
   "iife": "dist/latest-news.js",


### PR DESCRIPTION
## Done

- Bumps package version to 2.1.0 so we can release https://github.com/canonical/latest-news/pull/55 and https://github.com/canonical/latest-news/pull/53
