### PR TITLE
[WD-31330] use different endpoints depending on the language parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ The script will look for the following class names to use as hooks for content w
 
 You can choose what content to display and how it will look by using the above classes. If you don't want a certain part of the content, for example the article image, then do not include an element with the class name of `article-image`.
 
+#### Blog Pattern
+
+You can also render blog posts fetched by this module using Jinja pattern called `Blog`. More information about the pattern and its usage can be found in the [Vanilla documentation](https://vanillaframework.io/docs/patterns/blog#:~:text=and%20citation%20metadata.-,Dynamic%20content,-For%20scenarios%20where).
+
 ### Options
 
 You will need to pass some options to the script in order for it to know where the template is and where it should be rendered to. These are:
@@ -90,6 +94,7 @@ You will need to pass some options to the script in order for it to know where t
 - `tagIds`: String(comma separated tagids i.e. "id1,id2,id3") - Return posts with all tags (Optional)
 - `excerptLength`: Integer - Specifies the approximate number of characters included in the excerpt (Optional)
 - `lazyLoadImage`: Boolean - Enable lazy loading for images to improve page performance by loading images only when they enter the viewport. By default, it is true (Optional)
+- `lang`: String - Defines the language in which blog posts are written. Available options are `cn` and `jp`. If not specified, English is used (Optional)
 
 ## Building
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/latest-news",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A script that loads blogs posts into a given template",
   "main": "src/index.js",
   "iife": "dist/latest-news.js",

--- a/src/index.js
+++ b/src/index.js
@@ -234,8 +234,16 @@ function latestArticlesCallback(options) {
 }
 
 function fetchLatestNews(options) {
-  var url = "https://ubuntu.com/blog/latest-news";
-  var params = [];
+  let url = `https://ubuntu.com/blog/latest-news`;
+  if (options.lang) {
+    if (options.lang == "cn") {
+      url = "https://ubuntu.com/cn-blog/latest-news";
+    } else if (options.lang == "jp") {
+      url = "https://ubuntu.com/jp-blog/latest-news";
+    }
+  }
+
+  const params = [];
   revealSection();
 
   if (options.limit) {
@@ -243,7 +251,7 @@ function fetchLatestNews(options) {
   }
 
   if (options.tagIds) {
-    var tagIdArray = options.tagIds.split(",").map(function (id) {
+    const tagIdArray = options.tagIds.split(",").map(function (id) {
       return id.trim();
     });
     tagIdArray.forEach(function (id) {
@@ -261,7 +269,7 @@ function fetchLatestNews(options) {
     url += "?" + params.join("&");
   }
 
-  var oReq = new XMLHttpRequest();
+  const oReq = new XMLHttpRequest();
   oReq.addEventListener("load", latestArticlesCallback(options));
   oReq.open("GET", url);
   oReq.send();


### PR DESCRIPTION
## Done

- Add new key to `options` param called `lang` that defines which endpoints should be called to return blogs. New endpoints `/cn-blog/latest-news` and `/jp-blogs/latest-news` are added on ubuntu.com in [this PR](https://github.com/canonical/ubuntu.com/pull/15825).

## Issue / Card

Needed for https://warthogs.atlassian.net/browse/WD-31330

