### PR TITLE
use same URL for blogs API, but add additional parameter to change it

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You will need to pass some options to the script in order for it to know where t
 - `tagIds`: String(comma separated tagids i.e. "id1,id2,id3") - Return posts with all tags (Optional)
 - `excerptLength`: Integer - Specifies the approximate number of characters included in the excerpt (Optional)
 - `lazyLoadImage`: Boolean - Enable lazy loading for images to improve page performance by loading images only when they enter the viewport. By default, it is true (Optional)
-- `lang`: String - Defines the language in which blog posts are written. Available options are `cn` and `jp`. If not specified, English is used (Optional)
+- `url`: String - By default API URL is `/blog/latest-news`, but in case it should be something else you can pass this optional parameter (Optional)
 
 ## Building
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/latest-news",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A script that loads blogs posts into a given template",
   "main": "src/index.js",
   "iife": "dist/latest-news.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/latest-news",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A script that loads blogs posts into a given template",
   "main": "src/index.js",
   "iife": "dist/latest-news.js",

--- a/src/index.js
+++ b/src/index.js
@@ -234,14 +234,7 @@ function latestArticlesCallback(options) {
 }
 
 function fetchLatestNews(options) {
-  let url = `https://ubuntu.com/blog/latest-news`;
-  if (options.lang) {
-    if (options.lang == "cn") {
-      url = "https://ubuntu.com/cn-blog/latest-news";
-    } else if (options.lang == "jp") {
-      url = "https://ubuntu.com/jp-blog/latest-news";
-    }
-  }
+  let url = options.url || "/blog/latest-news";
 
   const params = [];
   revealSection();


### PR DESCRIPTION
## Problem description

- Previously the idea was to use different URLs for regional and other websites to fetch blogs using `/latest-news` endpoint (which is used by [Blog pattern](https://vanillaframework.io/docs/patterns/blog)). But it appears that all websites have their own blueprint for `/blog` endpoints. And for that reason it's better to use that, because every website can define their own set of included and excluded tags and should be able to fetch corresponding blogs. For that reason I removed the domain and left only `/blog/latest-news` as the URL, so that each website can call its own endpoint.
- Also I added an optional `url` key to `options` parameter, just in case there is a specific scenario when we need to use another URL to fetch blogs. This is purely for flexibility purpose, otherwise hardcoded URL doesn't feel very right.

## QA

- Check that all the following websites alredy have their own `/blog/latest-news` endpoints:
   - https://ubuntu.com/blog/latest-news
   - https://canonical.com/latest-news
   - https://cn.ubuntu.com/latest-news
   - https://jp.ubuntu.com/latest-news
   - https://snapcraft.io/blog/latest-news

Here's how to test if the new logic still works as expected for all websites:
- Clone this repo locally and run `yarn build`
- Copy the content of the file `dist/latest-news.js`
- In another repository (let's say ubuntu.com) find a reference to `{{ versioned_static('<some path>/latest-news.js') }}` and open the file that is being referenced. And put the content that you copied before to this file.
- Launch the website using `dotrun`
- Open the page that has the reference to `{{ versioned_static('<some path>/latest-news.js') }}` and scroll to the section where blogs should be shown.
- Check that the blogs are rendering similar to production.

## Issue / Card

Needed for https://warthogs.atlassian.net/browse/WD-31330
